### PR TITLE
feat(#9): 결제 완료 요청 시 상태 값 변경 및 후처리 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,6 +41,10 @@ dependencies {
 
     // jasypt for encoding properties
     implementation group: 'com.github.ulisesbocchio', name: 'jasypt-spring-boot-starter', version: '3.0.5'
+
+    //aws
+    implementation 'software.amazon.awssdk:scheduler:2.20.103'
+    implementation 'software.amazon.awssdk:eventbridge:2.20.102'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/bs/payment/apis/ReservationRestClient.java
+++ b/src/main/java/com/bs/payment/apis/ReservationRestClient.java
@@ -1,0 +1,40 @@
+package com.bs.payment.apis;
+
+import com.bs.payment.dtos.response.CommonResponseDto;
+import com.bs.payment.exceptions.internalServer.ExternalServiceException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class ReservationRestClient {
+
+    private final RestTemplate restTemplate;
+
+    @Value("${external.service.reservation.url}")
+    private String externalServiceReservationUrl;
+
+    @Transactional
+    public void makeReservationComplete(final Long id) {
+
+        log.info("makeReservationComplete with ID: {}", id);
+
+        String url = externalServiceReservationUrl + "/reservations/" + id;
+        HttpEntity<?> request = new HttpEntity<>(null);
+
+        ResponseEntity<CommonResponseDto> response = restTemplate.exchange(url, HttpMethod.PUT, request, CommonResponseDto.class);
+
+        if(!response.getStatusCode().is2xxSuccessful() || response.getBody() == null) {
+            throw new ExternalServiceException("Sessions seats not created. HTTP Status: " + response.getStatusCode());
+        }
+    }
+
+}

--- a/src/main/java/com/bs/payment/apis/SchedulerServiceClient.java
+++ b/src/main/java/com/bs/payment/apis/SchedulerServiceClient.java
@@ -13,14 +13,12 @@ import software.amazon.awssdk.services.scheduler.model.GetScheduleResponse;
 @Service
 @RequiredArgsConstructor
 @Slf4j
-@Transactional(readOnly = true)
 public class SchedulerServiceClient {
 
     private static final String RESERVATION_PREFIX = "Reservation-";
     private static final String SCHEDULE_SUFFIX = "-time_out_schedule";
     private final SchedulerClient schedulerClient;
 
-    @Transactional
     public void deleteTimeOutSchedule(Long reservationId, String userId) {
 
         log.info("Attempting to delete schedule for reservationId: {}, userId: {}", reservationId, userId);

--- a/src/main/java/com/bs/payment/apis/SchedulerServiceClient.java
+++ b/src/main/java/com/bs/payment/apis/SchedulerServiceClient.java
@@ -1,0 +1,55 @@
+package com.bs.payment.apis;
+
+import com.bs.payment.exceptions.internalServer.SchedulerNotFoundException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import software.amazon.awssdk.services.scheduler.SchedulerClient;
+import software.amazon.awssdk.services.scheduler.model.DeleteScheduleRequest;
+import software.amazon.awssdk.services.scheduler.model.GetScheduleRequest;
+import software.amazon.awssdk.services.scheduler.model.GetScheduleResponse;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class SchedulerServiceClient {
+
+    private static final String RESERVATION_PREFIX = "Reservation-";
+    private static final String SCHEDULE_SUFFIX = "-time_out_schedule";
+    private final SchedulerClient schedulerClient;
+
+    @Transactional
+    public void deleteTimeOutSchedule(Long reservationId, String userId) {
+
+        log.info("Attempting to delete schedule for reservationId: {}, userId: {}", reservationId, userId);
+
+        String scheduleName = buildScheduleName(reservationId, userId);
+
+        if (!isScheduleExists(scheduleName)) {
+            throw new SchedulerNotFoundException(reservationId.toString(), userId);
+        }
+
+        DeleteScheduleRequest deleteScheduleRequest = DeleteScheduleRequest.builder()
+                .name(scheduleName)
+                .build();
+
+        schedulerClient.deleteSchedule(deleteScheduleRequest);
+
+    }
+
+    private boolean isScheduleExists(String scheduleName) {
+        GetScheduleRequest request = GetScheduleRequest.builder()
+                .name(scheduleName)
+                .build();
+        GetScheduleResponse getScheduleResponse = schedulerClient.getSchedule(request);
+
+        return getScheduleResponse != null;
+    }
+
+    private String buildScheduleName(Long reservationId, String userId) {
+        return RESERVATION_PREFIX + reservationId + "-" + userId + SCHEDULE_SUFFIX;
+    }
+
+}

--- a/src/main/java/com/bs/payment/configs/RestTemplateConfig.java
+++ b/src/main/java/com/bs/payment/configs/RestTemplateConfig.java
@@ -1,0 +1,14 @@
+package com.bs.payment.configs;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
+
+@Configuration
+public class RestTemplateConfig {
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+
+}

--- a/src/main/java/com/bs/payment/configs/SchedulerConfig.java
+++ b/src/main/java/com/bs/payment/configs/SchedulerConfig.java
@@ -1,0 +1,17 @@
+package com.bs.payment.configs;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.scheduler.SchedulerClient;
+
+@Configuration
+public class SchedulerConfig {
+    @Bean
+    public SchedulerClient schedulerClient() {
+
+        return SchedulerClient.builder()
+                .region(Region.AP_NORTHEAST_2)
+                .build();
+    }
+}

--- a/src/main/java/com/bs/payment/controllers/PaymentController.java
+++ b/src/main/java/com/bs/payment/controllers/PaymentController.java
@@ -7,14 +7,7 @@ import com.bs.payment.services.PaymentService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.ResponseStatus;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -42,5 +35,13 @@ public class PaymentController {
     @ResponseStatus(HttpStatus.OK)
     public PaymentGetResponseDto getPayment(@PathVariable final Long id) {
         return paymentService.getPaymentById(id);
+    }
+
+
+    @PutMapping("/{id}/complete")
+    @ResponseStatus(HttpStatus.OK)
+    public CommonResponseDto paymentComplete(@PathVariable final Long id) {
+        paymentService.complete(id);
+        return new CommonResponseDto(HttpStatus.OK.toString(), "Payment status updated successfully");
     }
 }

--- a/src/main/java/com/bs/payment/controllers/PaymentController.java
+++ b/src/main/java/com/bs/payment/controllers/PaymentController.java
@@ -41,7 +41,7 @@ public class PaymentController {
     @PutMapping("/{id}/complete")
     @ResponseStatus(HttpStatus.OK)
     public CommonResponseDto paymentComplete(@PathVariable final Long id) {
-        paymentService.complete(id);
+        paymentService.completePayment(id);
         return new CommonResponseDto(HttpStatus.OK.toString(), "Payment status updated successfully");
     }
 }

--- a/src/main/java/com/bs/payment/dtos/response/PaymentGetResponseDto.java
+++ b/src/main/java/com/bs/payment/dtos/response/PaymentGetResponseDto.java
@@ -12,17 +12,17 @@ import lombok.Setter;
 @Setter
 @Builder
 @AllArgsConstructor
-@NoArgsConstructor(force = true)
+@NoArgsConstructor
 public class PaymentGetResponseDto {
 
-    private final Long reservationId;
+    private Long reservationId;
 
-    private final Long price;
+    private Long price;
 
-    private final PaymentStatus status;
+    private PaymentStatus status;
 
-    private final PaymentType type;
+    private PaymentType type;
 
-    private final String userId;
+    private String userId;
 
 }

--- a/src/main/java/com/bs/payment/exceptions/GlobalExceptionHandler.java
+++ b/src/main/java/com/bs/payment/exceptions/GlobalExceptionHandler.java
@@ -2,6 +2,8 @@ package com.bs.payment.exceptions;
 
 import com.bs.payment.dtos.response.ErrorResultResponseDto;
 import com.bs.payment.exceptions.badReqeust.InvalidValueException;
+import com.bs.payment.exceptions.internalServer.ExternalServiceException;
+import com.bs.payment.exceptions.internalServer.InternalServiceException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
@@ -32,6 +34,19 @@ public class GlobalExceptionHandler {
     public ErrorResultResponseDto handleIllegalArgumentException(IllegalArgumentException e) {
         log.error("[IllegalArgumentException] e", e);
         return new ErrorResultResponseDto(HttpStatus.BAD_REQUEST.toString(), e.getMessage());
+    }
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(InternalServiceException.class)
+    public ErrorResultResponseDto handleInternalServiceException(InternalServiceException e) {
+        log.error("[InternalServiceException] ex", e.getMessage());
+        return new ErrorResultResponseDto(HttpStatus.INTERNAL_SERVER_ERROR.toString(), e.getMessage());
+    }
+
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+    @ExceptionHandler(ExternalServiceException.class)
+    public ErrorResultResponseDto handleExternalServiceException(ExternalServiceException e) {
+        log.error("[ExternalServiceException] ex", e.getMessage());
+        return new ErrorResultResponseDto(HttpStatus.INTERNAL_SERVER_ERROR.toString(), e.getMessage());
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/src/main/java/com/bs/payment/exceptions/internalServer/ExternalServiceException.java
+++ b/src/main/java/com/bs/payment/exceptions/internalServer/ExternalServiceException.java
@@ -1,0 +1,8 @@
+package com.bs.payment.exceptions.internalServer;
+
+public class ExternalServiceException extends RuntimeException {
+
+    public ExternalServiceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/bs/payment/exceptions/internalServer/InternalServiceException.java
+++ b/src/main/java/com/bs/payment/exceptions/internalServer/InternalServiceException.java
@@ -1,0 +1,8 @@
+package com.bs.payment.exceptions.internalServer;
+
+public class InternalServiceException extends RuntimeException {
+
+    public InternalServiceException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/bs/payment/exceptions/internalServer/InvalidPaymentStatusException.java
+++ b/src/main/java/com/bs/payment/exceptions/internalServer/InvalidPaymentStatusException.java
@@ -1,0 +1,8 @@
+package com.bs.payment.exceptions.internalServer;
+public class InvalidPaymentStatusException extends InternalServiceException {
+    private static final String INVALID_STATUS_MESSAGE_FORMAT = "Invalid payment status change. Current status: %s, Requested change: %s";
+
+    public InvalidPaymentStatusException(String currentStatus, String requestedChange) {
+        super(String.format(INVALID_STATUS_MESSAGE_FORMAT, currentStatus, requestedChange));
+    }
+}

--- a/src/main/java/com/bs/payment/exceptions/internalServer/SchedulerNotFoundException.java
+++ b/src/main/java/com/bs/payment/exceptions/internalServer/SchedulerNotFoundException.java
@@ -1,0 +1,9 @@
+package com.bs.payment.exceptions.internalServer;
+
+public class SchedulerNotFoundException extends ExternalServiceException {
+    private static final String SCHEDULE_NOT_FOUND_MESSAGE_FORMAT = "Schedule not found for reservationId: %s and userId: %s";
+
+    public SchedulerNotFoundException(String reservationId, String userId) {
+        super(String.format(SCHEDULE_NOT_FOUND_MESSAGE_FORMAT, reservationId, userId));
+    }
+}

--- a/src/main/java/com/bs/payment/models/Payment.java
+++ b/src/main/java/com/bs/payment/models/Payment.java
@@ -2,6 +2,7 @@ package com.bs.payment.models;
 
 import com.bs.payment.enums.PaymentStatus;
 import com.bs.payment.enums.PaymentType;
+import com.bs.payment.exceptions.internalServer.InvalidPaymentStatusException;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -60,4 +61,13 @@ public class Payment extends BaseEntity {
         this.isDeleted = true;
         this.deletedAt = LocalDateTime.now();
     }
+
+    public void makeComplete() {
+        if (this.status != PaymentStatus.PENDING) {
+            throw new InvalidPaymentStatusException(this.status.toString(), PaymentStatus.COMPLETE.toString());
+        }
+        this.payedAt = LocalDateTime.now();
+        this.status = PaymentStatus.COMPLETE;
+    }
+
 }

--- a/src/main/java/com/bs/payment/repositories/PaymentRepository.java
+++ b/src/main/java/com/bs/payment/repositories/PaymentRepository.java
@@ -4,8 +4,10 @@ import com.bs.payment.models.Payment;
 
 import java.util.Optional;
 
-import lombok.NonNull;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.repository.query.Param;
 
 public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
@@ -13,4 +15,6 @@ public interface PaymentRepository extends JpaRepository<Payment, Long> {
 
     boolean existsByReservationIdAndUserIdAndIsDeletedFalse(Long reservationId, String userId);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    Optional<Payment> findWithLockingByIdAndIsDeletedFalse(@Param("id") Long id);
 }

--- a/src/main/java/com/bs/payment/services/PaymentService.java
+++ b/src/main/java/com/bs/payment/services/PaymentService.java
@@ -8,5 +8,5 @@ public interface PaymentService {
     void createPayment(PaymentCreateDto paymentCreateDto);
     void deletePayment(final Long id);
     PaymentGetResponseDto getPaymentById(Long id);
-
+    void complete(final Long id);
 }

--- a/src/main/java/com/bs/payment/services/PaymentService.java
+++ b/src/main/java/com/bs/payment/services/PaymentService.java
@@ -8,5 +8,5 @@ public interface PaymentService {
     void createPayment(PaymentCreateDto paymentCreateDto);
     void deletePayment(final Long id);
     PaymentGetResponseDto getPaymentById(Long id);
-    void complete(final Long id);
+    void completePayment(final Long id);
 }

--- a/src/main/java/com/bs/payment/services/PaymentServiceImpl.java
+++ b/src/main/java/com/bs/payment/services/PaymentServiceImpl.java
@@ -1,5 +1,7 @@
 package com.bs.payment.services;
 
+import com.bs.payment.apis.ReservationRestClient;
+import com.bs.payment.apis.SchedulerServiceClient;
 import com.bs.payment.dtos.request.PaymentCreateDto;
 import com.bs.payment.dtos.response.PaymentGetResponseDto;
 import com.bs.payment.exceptions.badReqeust.PaymentAlreadyExistsException;
@@ -19,7 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class PaymentServiceImpl implements PaymentService {
 
     private final ModelMapper modelMapper;
-
+    private final ReservationRestClient reservationRestClient;
+    private final SchedulerServiceClient schedulerServiceClient;
     private final PaymentRepository paymentRepository;
 
     @Override
@@ -59,8 +62,26 @@ public class PaymentServiceImpl implements PaymentService {
         return modelMapper.map(payment, PaymentGetResponseDto.class);
     }
 
+    @Override
+    @Transactional
+    public void complete(Long id) {
+
+        log.info("Attempting to change payment status with ID: {}", id);
+
+        Payment payment = paymentRepository.findWithLockingByIdAndIsDeletedFalse(id)
+                .orElseThrow(() -> new ResourceNotFoundException("Payment", String.valueOf(id)));
+
+        payment.makeComplete();
+
+        reservationRestClient.makeReservationComplete(id);
+
+        schedulerServiceClient.deleteTimeOutSchedule(payment.getReservationId(), payment.getUserId());
+
+    }
+
     private Payment getPayment(Long paymentId) {
         return paymentRepository.findByIdAndIsDeletedFalse(paymentId)
                 .orElseThrow(() -> new ResourceNotFoundException("Payment", String.valueOf(paymentId)));
     }
+
 }

--- a/src/main/java/com/bs/payment/services/PaymentServiceImpl.java
+++ b/src/main/java/com/bs/payment/services/PaymentServiceImpl.java
@@ -64,7 +64,7 @@ public class PaymentServiceImpl implements PaymentService {
 
     @Override
     @Transactional
-    public void complete(Long id) {
+    public void completePayment(Long id) {
 
         log.info("Attempting to change payment status with ID: {}", id);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -16,3 +16,6 @@ spring.jpa.properties.hibernate.id.new_generator_mappings = true
 
 # /api-docs endpoint custom path
 springdoc.api-docs.path=/api-docs
+
+# external service settings
+external.service.reservation.url=https://99hj5u45wf.execute-api.ap-northeast-2.amazonaws.com/api

--- a/src/test/java/com/bs/payment/controllers/PaymentControllerTest.java
+++ b/src/test/java/com/bs/payment/controllers/PaymentControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -103,6 +104,29 @@ class PaymentControllerTest {
         doThrow(ResourceNotFoundException.class).when(paymentService).getPaymentById(paymentId);
 
         mockMvc.perform(get("/payments/" + paymentId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("유효한 결제 ID로 결제 상태 업데이트 API 호출 시 성공")
+    void testPaymentCompleteSuccess() throws Exception {
+
+        doNothing().when(paymentService).complete(paymentId);
+
+        mockMvc.perform(put("/payments/" + paymentId + "/complete")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.message").value("Payment status updated successfully"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 결제 ID로 결제 상태 업데이트 API 호출 시 실패")
+    void testPaymentCompleteFailure() throws Exception {
+
+        doThrow(ResourceNotFoundException.class).when(paymentService).complete(paymentId);
+
+        mockMvc.perform(put("/payments/" + paymentId + "/complete")
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isBadRequest());
     }

--- a/src/test/java/com/bs/payment/controllers/PaymentControllerTest.java
+++ b/src/test/java/com/bs/payment/controllers/PaymentControllerTest.java
@@ -112,7 +112,7 @@ class PaymentControllerTest {
     @DisplayName("유효한 결제 ID로 결제 상태 업데이트 API 호출 시 성공")
     void testPaymentCompleteSuccess() throws Exception {
 
-        doNothing().when(paymentService).complete(paymentId);
+        doNothing().when(paymentService).completePayment(paymentId);
 
         mockMvc.perform(put("/payments/" + paymentId + "/complete")
                         .contentType(MediaType.APPLICATION_JSON))
@@ -124,7 +124,7 @@ class PaymentControllerTest {
     @DisplayName("존재하지 않는 결제 ID로 결제 상태 업데이트 API 호출 시 실패")
     void testPaymentCompleteFailure() throws Exception {
 
-        doThrow(ResourceNotFoundException.class).when(paymentService).complete(paymentId);
+        doThrow(ResourceNotFoundException.class).when(paymentService).completePayment(paymentId);
 
         mockMvc.perform(put("/payments/" + paymentId + "/complete")
                         .contentType(MediaType.APPLICATION_JSON))

--- a/src/test/java/com/bs/payment/services/PaymentServiceImplTest.java
+++ b/src/test/java/com/bs/payment/services/PaymentServiceImplTest.java
@@ -127,13 +127,13 @@ class PaymentServiceImplTest {
     }
 
     @Test
-    @DisplayName("유효한 결제 ID가 주어졌을 때, 결제 상태를 정상적으로 COMPLETE로 변경")
-    void completePaymentSuccessTest() {
+    @DisplayName("유효한 결제 ID가 주어졌을 때, 결제 상태를 정상적으로 completePayment로 변경")
+    void completePaymentPaymentSuccessTest() {
 
         doReturn(Optional.of(payment)).when(paymentRepository)
                 .findWithLockingByIdAndIsDeletedFalse(paymentId);
 
-        paymentService.complete(paymentId);
+        paymentService.completePayment(paymentId);
 
         assertEquals(PaymentStatus.COMPLETE, payment.getStatus());
         verify(paymentRepository).findWithLockingByIdAndIsDeletedFalse(paymentId);
@@ -141,13 +141,13 @@ class PaymentServiceImplTest {
 
     @Test
     @DisplayName("존재하지 않는 결제 ID가 주어졌을 때, 결제 상태 변경 시 ResourceNotFoundException 예외 발생")
-    void completePaymentWithInvalidIdTest() {
+    void completePaymentPaymentWithInvalidIdTest() {
 
         doReturn(Optional.empty()).when(paymentRepository)
                 .findWithLockingByIdAndIsDeletedFalse(paymentId);
 
         assertThrows(ResourceNotFoundException.class,
-                () -> paymentService.complete(paymentId));
+                () -> paymentService.completePayment(paymentId));
     }
 
     private static Payment getPayment() {

--- a/src/test/java/com/bs/payment/services/PaymentServiceImplTest.java
+++ b/src/test/java/com/bs/payment/services/PaymentServiceImplTest.java
@@ -4,10 +4,10 @@ import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 
+import com.bs.payment.apis.ReservationRestClient;
+import com.bs.payment.apis.SchedulerServiceClient;
 import com.bs.payment.dtos.request.PaymentCreateDto;
 import com.bs.payment.dtos.response.PaymentGetResponseDto;
 import com.bs.payment.enums.PaymentStatus;
@@ -17,6 +17,10 @@ import com.bs.payment.exceptions.badReqeust.ResourceNotFoundException;
 import com.bs.payment.models.Payment;
 import com.bs.payment.repositories.PaymentRepository;
 import java.util.Optional;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -34,7 +38,10 @@ class PaymentServiceImplTest {
 
     @Mock
     ModelMapper modelMapper;
-
+    @Mock
+    ReservationRestClient reservationRestClient;
+    @Mock
+    SchedulerServiceClient schedulerServiceClient;
     @Mock
     private PaymentRepository paymentRepository;
 
@@ -119,6 +126,30 @@ class PaymentServiceImplTest {
             () -> paymentService.getPaymentById(paymentId));
     }
 
+    @Test
+    @DisplayName("유효한 결제 ID가 주어졌을 때, 결제 상태를 정상적으로 COMPLETE로 변경")
+    void completePaymentSuccessTest() {
+
+        doReturn(Optional.of(payment)).when(paymentRepository)
+                .findWithLockingByIdAndIsDeletedFalse(paymentId);
+
+        paymentService.complete(paymentId);
+
+        assertEquals(PaymentStatus.COMPLETE, payment.getStatus());
+        verify(paymentRepository).findWithLockingByIdAndIsDeletedFalse(paymentId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 결제 ID가 주어졌을 때, 결제 상태 변경 시 ResourceNotFoundException 예외 발생")
+    void completePaymentWithInvalidIdTest() {
+
+        doReturn(Optional.empty()).when(paymentRepository)
+                .findWithLockingByIdAndIsDeletedFalse(paymentId);
+
+        assertThrows(ResourceNotFoundException.class,
+                () -> paymentService.complete(paymentId));
+    }
+
     private static Payment getPayment() {
         return Payment.builder()
             .reservationId(1L)
@@ -128,4 +159,5 @@ class PaymentServiceImplTest {
             .type(PaymentType.KAKAO_PAY)
             .build();
     }
+
 }


### PR DESCRIPTION
feat: 결제 상태 완료로 변경 로직 구현

feat: 결제 정보 조회 시 PESSIMISTIC_WRITE 잠금 모드 적용

feat: 예매 서비스에게 예매 완료 상태로 변경 요청

feat: 이벤트 브릿지의 타임아웃 스케쥴러 삭제

feat: 결제 완료 요청 시 상태 값 변경 및 후처리 구현

fix: 결제 조회 시 모든 값이 null로 조회되는 문제 개선